### PR TITLE
Fix the intents for Slobber

### DIFF
--- a/NewEnemyPack/Chapman.cs
+++ b/NewEnemyPack/Chapman.cs
@@ -1,5 +1,4 @@
 ﻿using BrutalAPI;
-using MarmoItems;
 using NewEnemyPack.Effectsa;
 using System;
 using System.Collections.Generic;

--- a/NewEnemyPack/Effectsa/ClassicPassiveAbility.cs
+++ b/NewEnemyPack/Effectsa/ClassicPassiveAbility.cs
@@ -1,5 +1,4 @@
 ﻿using BrutalAPI;
-using MarmoItems;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/NewEnemyPack/Intijar.cs
+++ b/NewEnemyPack/Intijar.cs
@@ -1,5 +1,4 @@
 ﻿using BrutalAPI;
-using MarmoItems;
 using NewEnemyPack.Effectsa;
 using System;
 using System.Collections.Generic;

--- a/NewEnemyPack/Neoplasms.cs
+++ b/NewEnemyPack/Neoplasms.cs
@@ -105,7 +105,7 @@ namespace NewEnemyPack
                 
 
             };
-            slobber.AddIntentsToTarget(Targeting.Slot_Front, new string[] { IntentType_GameIDs.Other_MaxHealth.ToString(), IntentType_GameIDs.Damage_3_6.ToString() });
+            slobber.AddIntentsToTarget(Targeting.Slot_Front, new string[] { IntentType_GameIDs.Other_MaxHealth.ToString() });
             slobber.AnimationTarget = Targeting.Slot_Front;
             slobber.Visuals = LoadedAssetsHandler.GetEnemyAbility("EarWorm_A").visuals;
 

--- a/NewEnemyPack/NewEnemyPack.csproj
+++ b/NewEnemyPack/NewEnemyPack.csproj
@@ -344,7 +344,6 @@
     <EmbeddedResource Include="Assets\EnemyPackSounds.bank" />
     <EmbeddedResource Include="Assets\EnemyPackSounds.strings.bank" />
     <EmbeddedResource Include="Assets\greyjumble" />
-    <EmbeddedResource Include="Assets\greyjumble.meta" />
     <EmbeddedResource Include="Textures\Achievements\BossButchererAch.png" />
     <EmbeddedResource Include="Textures\Achievements\CherubimAch.png" />
     <EmbeddedResource Include="Textures\Achievements\DeerAch.png" />
@@ -676,70 +675,64 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\References\BrutalOrchestra\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\BepInEx.dll</HintPath>
+      <HintPath>..\..\References\Bepinex\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="BrutalAPI">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\BrutalAPI.dll</HintPath>
+      <HintPath>..\..\References\BrutalOrchestra\BrutalAPI.dll</HintPath>
     </Reference>
     <Reference Include="FMODUnity">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\FMODUnity.dll</HintPath>
-    </Reference>
-    <Reference Include="MarmoItems">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\MarmoItems.dll</HintPath>
+      <HintPath>..\..\References\Unity\FMODUnity.dll</HintPath>
     </Reference>
     <Reference Include="Marosi.SerializableCollections">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\Marosi.SerializableCollections.dll</HintPath>
+      <HintPath>..\..\References\Unity\Marosi.SerializableCollections.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>..\..\References\Bepinex\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\MonoMod.Utils.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\References\Bepinex\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\..\References\Unity\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\..\References\Unity\UnityEngine.UIModule.dll</HintPath>
     </Reference>
     <Reference Include="YarnSpinner">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\YarnSpinner.dll</HintPath>
+      <HintPath>..\..\References\Unity\YarnSpinner.dll</HintPath>
     </Reference>
     <Reference Include="YarnSpinner.Compiler">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\YarnSpinner.Compiler.dll</HintPath>
+      <HintPath>..\..\References\Unity\YarnSpinner.Compiler.dll</HintPath>
     </Reference>
     <Reference Include="YarnSpinner.Unity">
-      <HintPath>..\..\..\..\OneDrive\Desktop\NewReferences\YarnSpinner.Unity.dll</HintPath>
+      <HintPath>..\..\References\Unity\YarnSpinner.Unity.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Removes the "painful amount of damage" intent from the Neoplasms' Slobber ability since it no longer deals damage.

<img width="502" height="211" alt="image" src="https://github.com/user-attachments/assets/e0aeeb55-2a8c-466d-854b-b165482c1ef4" />

Also changes how the project's references are set up, since it was needed to get the project to build.
The references are now located in these folders:
 * `repos/Bepinex`:
    * `BepInEx.dll`
    * `MonoMod.RuntimeDetour.dll`
    * `MonoMod.Utils.dll`
 * `repos/BrutalOrchestra`:
    * `Assembly-CSharp.dll`
    * `BrutalAPI.dll`
 * `repos/Unity`:
    * `FMODUnity.dll`
    * `Marosi.SerializableCollections.dll`
    * `Unity.TextMeshPro.dll`
    * `UnityEngine.dll`
    * `UnityEngine.AnimationModule.dll`
    * `UnityEngine.AssetBundleModule.dll`
    * `UnityEngine.AudioModule.dll`
    * `UnityEngine.CoreModule.dll`
    * `UnityEngine.ImageConversionModule.dll`
    * `UnityEngine.ParticleSystemModule.dll`
    * `UnityEngine.UI.dll`
    * `UnityEngine.UIModule.dll`
    * `YarnSpinner.dll`
    * `YarnSpinner.Compiler.dll`
    * `YarnSpinner.Unity.dll`

`repos` is the folder that contains this project.
